### PR TITLE
Add workflow-template for publishing Python project to PyPI

### DIFF
--- a/workflow-templates/README.md
+++ b/workflow-templates/README.md
@@ -1,0 +1,7 @@
+##Workflow templates
+
+This folder contains the OME GitHub workflow templates.
+
+### Additional references/links
+
+- https://packaging.python.org/guides/publishing-package-distribution-releases-using-github-actions-ci-cd-workflows/

--- a/workflow-templates/publish_pypi.yml
+++ b/workflow-templates/publish_pypi.yml
@@ -1,10 +1,10 @@
 ---
-name: Publish Python distributions to PyPI
+name: PyPI
 on: push
 
 jobs:
   build-n-publish:
-    name: Publish to PyPI
+    name: Build and publish Python distribution to PyPI
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2

--- a/workflow-templates/publish_pypi.yml
+++ b/workflow-templates/publish_pypi.yml
@@ -1,0 +1,20 @@
+---
+name: Publish Python distributions to PyPI
+on: push
+
+jobs:
+  build-n-publish:
+    name: Publish to PyPI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - name: Build a binary wheel and a source tarball
+        run: |
+          python -mpip install wheel
+          python setup.py sdist bdist_wheel
+      - name: Publish distribution to PyPI
+        if: startsWith(github.ref, 'refs/tags')
+        uses: pypa/gh-action-pypi-publish@v1.3.0
+        with:
+          password: ${{ secrets.PYPI_PASSWORD }}


### PR DESCRIPTION
Primarily inspired by the work on omero-cli-zarr this should make the standard publish to PyPI on tags workflow activatable at minimal cost across projects.

/cc @ome/python 