### PR TITLE
Add Tox workflow template

### DIFF
--- a/workflow-templates/tox.properties.json
+++ b/workflow-templates/tox.properties.json
@@ -1,0 +1,11 @@
+{
+    "name": "Run tox tests",
+    "description": "Run tox tests.",
+    "iconName": "python",
+    "categories": [
+        "Python"
+    ],
+    "filePatterns": [
+        "tox.ini$"
+    ]
+}

--- a/workflow-templates/tox.yml
+++ b/workflow-templates/tox.yml
@@ -1,0 +1,34 @@
+---
+name: Tox
+on:
+  schedule:
+    - cron: '0 0 * * 0'
+  push:
+  pull_request:
+
+jobs:
+  test:
+    name: Run tox tests
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version:
+          - '3.6'
+          - '3.7'
+          - '3.8'
+          - '3.9'
+    runs-on: ubuntu-20.04
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: ${{ matrix.python-version }}
+      - name: Install dependencies
+        run: python -mpip install --upgrade wheel pytest tox
+      - name: Get tox target
+        id: toxtarget
+        run: |
+          py=$(echo ${{ matrix.python-version }} | tr -d .)
+          echo "::set-output name=py::$py"
+      - name: Run tests
+        run: tox -e py${{ steps.toxtarget.outputs.py }}


### PR DESCRIPTION
Already implemented by a few repositories: [scc](https://github.com/ome/scc), [omero-web](https://github.com/ome/omero-py), [yaclifw](https://github.com/ome/yaclifw), [omero-dropbox](https://github.com/ome/omero-dropbox)