### PR TITLE
Gradle: fix creation of wrapper

### DIFF
--- a/workflow-templates/gradle.yml
+++ b/workflow-templates/gradle.yml
@@ -30,11 +30,21 @@ jobs:
           key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle') }}
           restore-keys: ${{ runner.os }}-gradle
       - name: Wrap with specified version
-        run: gradle wrapper --gradle-version=${{ env.gradle_version }}
+        run: |
+          DIR=$PWD 
+          cd /tmp 
+          gradle wrapper --gradle-version=${{ env.gradle_version }}
+          mv .gradle gradle gradlew $DIR
         if: ${{ env.gradle_version != '' }}
+        shell: bash
       - name: Wrap without version
-        run: gradle wrapper
+        run: |
+          DIR=$PWD 
+          cd /tmp 
+          gradle wrapper
+          mv .gradle gradle gradlew $DIR
         if: ${{ env.gradle_version == '' }}
+        shell: bash
       - name: Run commands
         run: ./gradlew ${{ env.gradle_commands }}
 


### PR DESCRIPTION
When creating the wrapper in the current directory, gradle already tries to build with the version currently installed (5.6.1). 
I only discovered the problem when working on ``omero-blitz``.
When this is merged, we can update the ``gradle.yml`` file in the various repositories or wait for the publication steps
 to be included.

Tested changes on all ubuntu, windows and mac: https://github.com/jburel/omero-model/actions/runs/411333070

